### PR TITLE
Mobile View fix

### DIFF
--- a/js/fsvs.js
+++ b/js/fsvs.js
@@ -233,7 +233,6 @@
 					if( touches && touches.length ) {
 						startY = touches[0].pageY;
 					}
-					e.preventDefault();
 				}
 			});
 			$(window).on( "touchmove.fsvs", function(ev) {


### PR DESCRIPTION
Remove "e.preventDefault()" line in bindTouchSwipe() function to enable default touch events (touch click etc.)
After that links, buttons etc. should work again on touchscreen devices.