### PR TITLE
Fix scrollable elements on mobiles

### DIFF
--- a/js/fsvs.js
+++ b/js/fsvs.js
@@ -227,6 +227,9 @@
     				if( $(e.target).parents(_cancelOn).length !== 0 ) {
     					cancel = true;
     				}
+					if( $(e.target).parents( '.' + options.scrollableArea ).length != 0 ){
+						cancel = true;
+					}
     			});
 				if( $.inArray( targetName, cancelOn ) == -1 && ! cancel ) {
 					var touches = e.touches;


### PR DESCRIPTION
Scrollable elements was ignored on mobiles. Touch swipe doesn't cancel on them.
I added check for touch target - is it a child of the node with scrollable class.
Now it works as should.