### PR TITLE
Add 'cancel' condition into bindMouseDrag() function

### DIFF
--- a/js/fsvs.js
+++ b/js/fsvs.js
@@ -189,14 +189,23 @@
 		 */
 
 		var bindMouseDrag = function() {
+			function isScrollable(element) {
+				return element.parents( '.' + options.scrollabelArea ).length != 0 ;
+			}
 			var x, y;
 			window.onmousedown = function(e) {
-				y = e.y;
+				var cancelOn = ['a','input','textarea','select'];
+				if( $.inArray( e.target.nodeName.toLowerCase(), cancelOn ) != -1 && isScrollable( $(e.target) ) ) {
+					cancel = true;
+				} else {
+					y = e.y;
+					cancel = false;
+				}
 			}
 			window.onmouseup = function(e) {
-				if( e.y > ( y+options.mouseSwipeDisance ) ) {
+				if( e.y > ( y+options.mouseSwipeDisance && !cancel ) ) {
 					app.slideUp();
-				} else if( e.y < ( y-options.mouseSwipeDisance ) ) {
+				} else if( e.y < ( y-options.mouseSwipeDisance && !cancel ) ) {
 					app.slideDown();
 				}
 			}


### PR DESCRIPTION
**Bug**: when you drag the scroll bar of scrollable element it fired up slideUp() or slideDown() function.

**Solution**: make check of scrollable elements like in bindTouchSwipe() function.
When mouseUp it will now check the 'cancel' value.
When I was trying to solve this in mouseDown function thet was bug that makes slideUp() or slideDown() fires when you click on dropdown menu sometimes, so I made it this way it is now.